### PR TITLE
fixed early ending bug

### DIFF
--- a/once_upon_an_arduino_ish.ino
+++ b/once_upon_an_arduino_ish.ino
@@ -157,9 +157,10 @@ void loop(){
       birdServo.write(180);
       speech2 = false;
       birdTimer2 = false;
+      birdDeath = true;
     }
 
-    if (badWellState == HIGH && !birdDeath){
+    if (badWellState == HIGH && birdDeath){
       wellServo.write(110);
       birdDeath = false;
       act3 = false;


### PR DESCRIPTION
Playtester put bird on the bird slot before putting the mouse in the kitchen, and ended the story early. I was debating keeping it in, as like an alternate ending but it wouldn't really make sense since the mouse has to eat somehow, and she doesn't exactly know how to do it right.